### PR TITLE
fix default resolution

### DIFF
--- a/create_commit_def.py
+++ b/create_commit_def.py
@@ -22,6 +22,7 @@ f.write('LATEST_COMMIT = "' + commit + '"\n')
 f.close()
 
 import os
+cwd = os.getcwd()
 os.chdir('cvlsshutils')
 
 if sys.platform.startswith("win"):
@@ -40,7 +41,7 @@ stdout = stdout.split('\n')[0].split()
 assert stdout[0] == 'commit'
 commit = stdout[1]
 
-os.chdir('..')
+os.chdir(cwd)
 
 f = open('commit_def.py', 'a')
 f.write('LATEST_COMMIT_CVLSSHUTILS = "' + commit + '"\n')

--- a/launcher.py
+++ b/launcher.py
@@ -1141,7 +1141,9 @@ class LauncherMainFrame(wx.Frame):
             try:
                 a=int(jobParams['resolution'][0])
             except:
-                displaySize = wx.DisplaySize()
+                display = wx.Display(0)
+                displaySize = display.GetGeometry().GetSize()
+                # displaySize = wx.DisplaySize()
                 desiredWidth = displaySize[0] * 0.99
                 desiredHeight = displaySize[1] * 0.85
                 jobParams['resolution'] = str(int(desiredWidth)) + "x" + str(int(desiredHeight))


### PR DESCRIPTION
Hi Chris,

this is the fix for the default resolution.

On my system (Linux,Gnome 3, two monitors) the default resolution returned by wx.DisplaySize() is the resolution of the whole desktop - but TurboVNC is only started in a window on one single screen.
Better is to set the default resolution to the resolution of the primary screen.

(commit 1 is unrelated and fixes a problem if cvlsshutils is just a link)

Best,
Jens Henrik