### PR TITLE
fix Fedora 23 problem + reduce submit-log-request

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -37,6 +37,8 @@ Windows: http://www.python.org/ftp/python/2.7.3/python-2.7.3.msi
 3.7 pexpect
 3.8 lxml
 3.9 psutil
+3.10 boto
+3.11 paramiko
 
 
 3.1 wx

--- a/LoginTasks.py
+++ b/LoginTasks.py
@@ -1576,8 +1576,8 @@ class LoginProcess():
                             logger.debug("LoginProcess.complete: User canceled login process between queueing the job and starting the job. System is probably busy. Not asking to submit a debug log .")
                             logger.dump_log(event.loginprocess.notify_window,submit_log=False)
                         else:
-                            logger.debug("LoginProcess.complete: loginprocess was canceled, asking user if they want to submit the log")
-                            logger.dump_log(event.loginprocess.notify_window,submit_log=True,jobParams=event.loginprocess.jobParams)
+                            logger.debug("LoginProcess.complete: login process was canceled. Do NOT asking user if they want to submit the log.")
+                            logger.dump_log(event.loginprocess.notify_window,submit_log=False,jobParams=event.loginprocess.jobParams)
                 logger.debug('loginProcessEvent: caught EVT_LOGINPROCESS_COMPLETE')
                 try:
                     wx.EndBusyCursor()

--- a/launcher.py
+++ b/launcher.py
@@ -1793,5 +1793,18 @@ class MyApp(wx.App):
         return True
 
 if __name__ == '__main__':
+    
+    # All multithread Xorg application need call XInitThreads before any work with Xorg or some xcb will abort with
+    #    [xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
+    # As XInitThreads is not garanteed to be called on all Linux distributions (like Fedora 23), we better do it here.
+    import sys
+    if sys.platform.startswith('linux'):
+        try:
+            import ctypes
+            x11 = ctypes.cdll.LoadLibrary('libX11.so.6')
+            x11.XInitThreads()
+        except:
+            pass
+        
     app = MyApp(False) # Don't automatically redirect sys.stdout and sys.stderr to a Window.
     app.MainLoop()

--- a/launcher.py
+++ b/launcher.py
@@ -425,8 +425,8 @@ class LauncherMainFrame(wx.Frame):
         widgetWidth2 = 180
         if not sys.platform.startswith("win"):
             widgetWidth2 = widgetWidth2 + 25
-        widgetWidth3 = 75
-
+        # widgetWidth3 = 75
+        widgetWidth3 = 100 # on Fedora 23 (XFCE4) the theme of the SpinCtrl will set "+" and "-" button side-by-side - this requires more space
 
         
         self.noneVisible={}

--- a/menus/IdentityMenu.py
+++ b/menus/IdentityMenu.py
@@ -76,6 +76,7 @@ class IdentityMenu(wx.Menu):
         self.launcherMainFrame.setPrefsSection('Global Preferences',options)
         self.launcherMainFrame.savePrefs(section='Global Preferences')
         self.disableItems(self.launcherMainFrame.TEMP_SSH_KEY)
+        self.launcherMainFrame.keyModelCreated.clear()
 
     def onPermSSHKey(self,event):
         options = self.launcherMainFrame.getPrefsSection('Global Preferences')
@@ -83,6 +84,7 @@ class IdentityMenu(wx.Menu):
         self.launcherMainFrame.setPrefsSection('Global Preferences',options)
         self.launcherMainFrame.savePrefs(section='Global Preferences')
         self.disableItems(self.launcherMainFrame.PERM_SSH_KEY)
+        self.launcherMainFrame.keyModelCreated.clear()        
 
     def setRadio(self,state):
         if state == self.launcherMainFrame.PERM_SSH_KEY:

--- a/optionsDialog.py
+++ b/optionsDialog.py
@@ -1321,5 +1321,5 @@ Don't remember me does not store this token permantly. You will need to enter a 
         saveFileDialog = wx.FileDialog ( None, message = 'TurboVNC Viewer...', wildcard = filters, style = wx.SAVE)
         if saveFileDialog.ShowModal() == wx.ID_OK:
             turboVncViewerFilePath = saveFileDialog.GetPath()
-            self.vncViewerFilePathTextField.WriteText(turboVncViewerFilePath)
+            self.vncViewerFilePathTextField.SetValue(turboVncViewerFilePath)
             

--- a/optionsDialog.py
+++ b/optionsDialog.py
@@ -261,7 +261,7 @@ class GlobalOptionsDialog(wx.Dialog):
         self.innerEncodingPanelSizer.Add(self.jpegChrominanceSubsamplingPanel, flag=wx.EXPAND)
 
         #self.jpegImageQualityLabel = wx.StaticText(self.innerEncodingPanel, wx.ID_ANY, "JPEG image quality:    95", style=wx.TE_READONLY)
-        self.jpegImageQualityLabel = wx.StaticText(self.innerEncodingPanel, wx.ID_ANY, "JPEG image quality:    " + str(self.encodingMethodsPresets['Tight + Perceptually Lossless JPEG (LAN)']['jpeg_image_quality']), style=wx.TE_READONLY)
+        self.jpegImageQualityLabel = wx.StaticText(self.innerEncodingPanel, wx.ID_ANY, "JPEG image quality:    " + str(self.encodingMethodsPresets['Tight + Perceptually Lossless JPEG (LAN)']['jpeg_image_quality']))
         self.jpegImageQualityLabel.SetFont(self.smallFont)
         self.innerEncodingPanelSizer.Add(self.jpegImageQualityLabel)
 


### PR DESCRIPTION
Strudel uses threading internally but "hopes" that someone else has call XInitThreads early.
A user reported, that this is not garanteed like in Fedora 23 with XFCE4.
I can reproduce his error which looks like this:

[xcb] Unknown request in queue while appending request
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that

All multithread Xorg application need call XInitThreads before any work with Xorg.
A fix for that would be to call the function if Strudel runs on Linux.
I found it at different places like here https://lists.gnu.org/archive/html/commit-gnuradio/2014-01/msg00031.html
This will not break anything (even if XInitThreads() has been called by someone else before) and makes Strudel more robust