### PR TITLE
check for launcher in $STRUDEL_DIR

### DIFF
--- a/strudel.sh
+++ b/strudel.sh
@@ -2,13 +2,21 @@
 
 STRUDEL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -f launcher ]; then
+## --- This can be a fix for systems, where libgio-2.0 is different to the build environment ---
+## add included libgio if not avail on system - use system if avail
+#LIBGIO_PATH=$(/sbin/ldconfig -p | grep  libgio-2.0.so.0)
+#if [ -z "$LIBGIO_PATH" ]; then
+#  echo "WARNING: libgio-2.0.so.0 not found on system - using build in version"
+#  LD_LIBRARY_PATH="${STRUDEL_DIR}"/bin/libgio:$LD_LIBRARY_PATH
+#fi
+
+if [ -f "${STRUDEL_DIR}"/launcher ]; then
   LD_LIBRARY_PATH="${STRUDEL_DIR}":$LD_LIBRARY_PATH
   "${STRUDEL_DIR}"/launcher
-elif [ -f bin/launcher ]; then
+elif [ -f "${STRUDEL_DIR}"/bin/launcher ]; then
   LD_LIBRARY_PATH="${STRUDEL_DIR}/bin":$LD_LIBRARY_PATH
   "${STRUDEL_DIR}"/bin/launcher
 else
   echo "ERROR: Cannot find launcher."
-fi  
+fi
 


### PR DESCRIPTION
Currently the user has to cd to the Strudel directory to make sure strudel.sh will find launcher.
This patch will make it possible to start strudel.sh from any directory without changing to the Strudel directory.