### PR TITLE
ignore ssh-output not belonging to cmd + make strudel.sh more robust

### DIFF
--- a/LoginTasks.py
+++ b/LoginTasks.py
@@ -164,11 +164,8 @@ class LoginProcess():
                 logger.debug("runServerCommandThread: self.cmd.format(**self.loginprocess.jobParams) gives an exception. Why wasn't this picked up earlier?")
     
             self.loginprocess.matchlist=[]
-
-            (stdout, stderr) = run_command(self.cmdRegex.getCmd(self.loginprocess.jobParams),ignore_errors=True, callback=self.loginprocess.cancel, startupinfo=self.loginprocess.startupinfo, creationflags=self.loginprocess.creationflags)            
-            (stdout, stderr) = self.cmdRegex.cleanupCmdOutput(stdout,stderr)            
             try:
-
+                (stdout, stderr) = run_command(self.cmdRegex.getCmd(self.loginprocess.jobParams),ignore_errors=True, callback=self.loginprocess.cancel, startupinfo=self.loginprocess.startupinfo, creationflags=self.loginprocess.creationflags)
                 logger.debug("runServerCommandThread: stderr = " + stderr)
                 logger.debug("runServerCommandThread: stdout = " + stdout)
             except Exception as e:

--- a/LoginTasks.py
+++ b/LoginTasks.py
@@ -164,8 +164,11 @@ class LoginProcess():
                 logger.debug("runServerCommandThread: self.cmd.format(**self.loginprocess.jobParams) gives an exception. Why wasn't this picked up earlier?")
     
             self.loginprocess.matchlist=[]
+
+            (stdout, stderr) = run_command(self.cmdRegex.getCmd(self.loginprocess.jobParams),ignore_errors=True, callback=self.loginprocess.cancel, startupinfo=self.loginprocess.startupinfo, creationflags=self.loginprocess.creationflags)            
+            (stdout, stderr) = self.cmdRegex.cleanupCmdOutput(stdout,stderr)            
             try:
-                (stdout, stderr) = run_command(self.cmdRegex.getCmd(self.loginprocess.jobParams),ignore_errors=True, callback=self.loginprocess.cancel, startupinfo=self.loginprocess.startupinfo, creationflags=self.loginprocess.creationflags)
+
                 logger.debug("runServerCommandThread: stderr = " + stderr)
                 logger.debug("runServerCommandThread: stdout = " + stdout)
             except Exception as e:

--- a/LoginTasks.py
+++ b/LoginTasks.py
@@ -166,6 +166,7 @@ class LoginProcess():
             self.loginprocess.matchlist=[]
             try:
                 (stdout, stderr) = run_command(self.cmdRegex.getCmd(self.loginprocess.jobParams),ignore_errors=True, callback=self.loginprocess.cancel, startupinfo=self.loginprocess.startupinfo, creationflags=self.loginprocess.creationflags)
+                (stdout, stderr) = self.cmdRegex.cleanupCmdOutput(stdout,stderr)
                 logger.debug("runServerCommandThread: stderr = " + stderr)
                 logger.debug("runServerCommandThread: stdout = " + stdout)
             except Exception as e:

--- a/strudel.sh
+++ b/strudel.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-STRUDEL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SOURCE=${BASH_SOURCE[0]} # for zsh this would be: SOURCE=${(%):-%N}
+STRUDEL_DIR="$( cd "$( dirname "${SOURCE}" )" && pwd )"
+if [ -L "${SOURCE}" ]; then 
+  LNK_TARGET=$(readlink "${SOURCE}")
+  STRUDEL_DIR="$( cd "$( dirname "${LNK_TARGET}" )" && pwd )" 
+fi
 
 ## --- This can be a fix for systems, where libgio-2.0 is different to the build environment ---
 ## add included libgio if not avail on system - use system if avail

--- a/strudel.sh
+++ b/strudel.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-SOURCE=${BASH_SOURCE[0]} # for zsh this would be: SOURCE=${(%):-%N}
-STRUDEL_DIR="$( cd "$( dirname "${SOURCE}" )" && pwd )"
-if [ -L "${SOURCE}" ]; then 
-  LNK_TARGET=$(readlink "${SOURCE}")
-  STRUDEL_DIR="$( cd "$( dirname "${LNK_TARGET}" )" && pwd )" 
-fi
+# get directory of strudel
+# this returns the correct absolute path to itself no matter how this script is called:
+# absolute/relative path, direct/nested symlink, script/symlink in $PATH and more ... 
+SOURCE="${BASH_SOURCE[0]}" # for zsh this would be: SCRIPT_PATH=${(%):-%N}
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  STRUDEL_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SOURCE != /* ]] && SOURCE="$STRUDEL_DIR/$SOURCE" 
+done
+STRUDEL_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 ## --- This can be a fix for systems, where libgio-2.0 is different to the build environment ---
 ## add included libgio if not avail on system - use system if avail
@@ -17,11 +22,10 @@ fi
 
 if [ -f "${STRUDEL_DIR}"/launcher ]; then
   LD_LIBRARY_PATH="${STRUDEL_DIR}":$LD_LIBRARY_PATH
-  "${STRUDEL_DIR}"/launcher
+  "${STRUDEL_DIR}"/launcher > ${HOME}/.strudel.log 2>&1
 elif [ -f "${STRUDEL_DIR}"/bin/launcher ]; then
   LD_LIBRARY_PATH="${STRUDEL_DIR}/bin":$LD_LIBRARY_PATH
-  "${STRUDEL_DIR}"/bin/launcher
+  "${STRUDEL_DIR}"/bin/launcher > ${HOME}/.strudel.log 2>&1
 else
   echo "ERROR: Cannot find launcher."
 fi
-


### PR DESCRIPTION
ignore ssh-output not belonging to cmd:
  this is an important one - if the users ~/.bashrc has any output strudel does not fail anymore

make strudel.sh more robust
  now you can call strudel.sh from $PATH, from a link, from a nested link, from relative path etc.