### PR TITLE
bugfix for cmd marker

### DIFF
--- a/LoginTasks.py
+++ b/LoginTasks.py
@@ -433,6 +433,7 @@ class LoginProcess():
                     time.sleep(sleepperiod)
                 try:
                     (stdout,stderr) = run_command(self.cmdRegex.getCmd(jobParams),ignore_errors=True, startupinfo=self.loginprocess.startupinfo, creationflags=self.loginprocess.creationflags)
+                    (stdout, stderr) = self.cmdRegex.cleanupCmdOutput(stdout,stderr)
                     logger.info("runLoopServerCommandThread: stderr = " + stderr)
                     logger.info("runLoopServerCommandThread: stdout = " + stdout)
                 except KeyError as e:

--- a/siteConfig.py
+++ b/siteConfig.py
@@ -289,12 +289,14 @@ class cmdRegEx():
     def getCmd(self,jobParam={}):
         if ('exec' in self.host):
             sshCmd = '{sshBinary} -A -T -o PasswordAuthentication=no -o ChallengeResponseAuthentication=no -o KbdInteractiveAuthentication=no -o PubkeyAuthentication=yes -o StrictHostKeyChecking=no -l {username} {execHost} '
+            # set marker line - this allows to ignore any output before the actual command            
+            sshCmd = sshCmd + ' \'echo -e \"\\n----- strudel stdout start -----\"; echo -e \"\\n----- strudel stderr start -----\" 1>&2; \' '            
         elif ('local' in self.host):
             sshCmd = ''
         else:
             sshCmd = '{sshBinary} -A -T -o PasswordAuthentication=no -o ChallengeResponseAuthentication=no -o KbdInteractiveAuthentication=no -o PubkeyAuthentication=yes -o StrictHostKeyChecking=yes -l {username} {loginHost} '
-        # set marker line - this allows to ignore any output before the actual command
-        sshCmd = sshCmd + ' \'echo -e \"\\n----- strudel stdout start -----\"; echo -e \"\\n----- strudel stderr start -----\" 1>&2; \' '
+            # set marker line - this allows to ignore any output before the actual command
+            sshCmd = sshCmd + ' \'echo -e \"\\n----- strudel stdout start -----\"; echo -e \"\\n----- strudel stderr start -----\" 1>&2; \' '
         cmd=self.cmd
         if sys.platform.startswith("win"):
             escapedChars={'ampersand':'^&','pipe':'^|'}


### PR DESCRIPTION
I introduced two bugs with the new cmd marker, sorry.
  1) cmd marker are only allowed to be used, if the command is executed not locally.
  2) cmd marker have to be cleaned from cmd output for runLoopServerCommandThread, too
This should fix these bugs now.


