### PR TITLE
fix marker recognition on Windows

### DIFF
--- a/LoginTasks.py
+++ b/LoginTasks.py
@@ -167,8 +167,8 @@ class LoginProcess():
             try:
                 (stdout, stderr) = run_command(self.cmdRegex.getCmd(self.loginprocess.jobParams),ignore_errors=True, callback=self.loginprocess.cancel, startupinfo=self.loginprocess.startupinfo, creationflags=self.loginprocess.creationflags)
                 (stdout, stderr) = self.cmdRegex.cleanupCmdOutput(stdout,stderr)
-                logger.debug("runServerCommandThread: stderr = " + stderr)
-                logger.debug("runServerCommandThread: stdout = " + stdout)
+                logger.debug("runServerCommandThread: stderr = " + repr(stderr))
+                logger.debug("runServerCommandThread: stdout = " + repr(stdout))
             except Exception as e:
                 logger.error("could not format the command in runServerCommandThread %s)"%self.cmdRegex.cmd)
                 logger.error("the error returned was %s"%e)

--- a/siteConfig.py
+++ b/siteConfig.py
@@ -1,5 +1,6 @@
 import json
 import sys
+import os
 import collections
 import requests
 from logger.Logger import logger
@@ -325,20 +326,23 @@ class cmdRegEx():
         return string
 
     def cleanupCmdOutput(self, stdout, stderr):    
-        import re
+                                   
+        def cleanupSingleOutput(output, marker_line):
+            
+            # remove any line in stdout above the marker line set in getCmd()             
+            output = output.splitlines()
+            try:
+                ii=output.index(marker_line) # exception ValueError if not found
+                if not output[ii+1:]: 
+                    output.append("")
+                output = os.linesep.join(output[ii+1:])
+            except ValueError:
+                print "marker string not found"
+                output = os.linesep.join(output[:])
+            return output                                            
 
-        # remove any line in stdout above the markter line set in getCmd()
-        stdout = stdout.split('\n')
-        regex_stdout = '^----- strudel stdout start -----$'       
-        lineIndex = [i for i in range(len(stdout)) if re.search(regex_stdout, stdout[i])]
-        stdout = '\n'.join(stdout[lineIndex[0]+1:]) # +1 always allowed, as marker line includes a return at the end
-                                                
-        # remove any line in stderr above the marker line  set in getCmd()
-        stderr = stderr.split('\n')
-        regex_stderr = '^----- strudel stderr start -----$'
-        lineIndex = [i for i in range(len(stderr)) if re.search(regex_stderr, stderr[i])]
-        print lineIndex[0]
-        stderr = '\n'.join(stderr[lineIndex[0]+1:]) # +1 always allowed, as marker line includes a return at the end   
+        stdout = cleanupSingleOutput(stdout, "----- strudel stdout start -----" )
+        stderr = cleanupSingleOutput(stderr, "----- strudel stderr start -----" )     
         
         return stdout, stderr
 

--- a/utilityFunctions.py
+++ b/utilityFunctions.py
@@ -500,8 +500,8 @@ def run_command(command,ignore_errors=False,log_output=True,callback=None,startu
         t.cancel()
         ssh_process.wait()
         if log_output:
-            logger.debug('command stdout: %s' % stdout)
-            logger.debug('command stderr: %s' % stderr)
+            logger.debug('command stdout: %s' % repr(stdout))
+            logger.debug('command stderr: %s' % repr(stderr))
         if not ignore_errors and len(stderr) > 0:
             error_message = 'Error running command: "%s" at line %d' % (command, inspect.stack()[1][2])
             logger.error('Nonempty stderr and ignore_errors == False; exiting the launcher with error dialog: ' + error_message)


### PR DESCRIPTION
This fixes a problem with different return codes on Linux and Windows.
The marker line could not be cleaned from the stdout and stderr and could result on Windows in the exception "list index out of range"