### PR TITLE
Marker string from strudel stderr was incorrectly formated (missing a…

### DIFF
--- a/siteConfig.py
+++ b/siteConfig.py
@@ -291,7 +291,7 @@ class cmdRegEx():
         if ('exec' in self.host):
             sshCmd = '{sshBinary} -A -T -o PasswordAuthentication=no -o ChallengeResponseAuthentication=no -o KbdInteractiveAuthentication=no -o PubkeyAuthentication=yes -o StrictHostKeyChecking=no -l {username} {execHost} '
             # set marker line - this allows to ignore any output before the actual command
-            sshCmd = sshCmd + ' \'(echo -e \"\\n----- strudel stdout start -----\");\' ' + ' \'(perl -e \"print STDERR \\"\\n----- strudel stderr start -----\\"\");\' '
+            sshCmd = sshCmd + ' \'(echo -e \"\\n----- strudel stdout start -----\");\' ' + ' \'(perl -e \"print STDERR \\"\\n----- strudel stderr start -----\\n\\"\");\' '
 			# INFO: If we echo partly to stderr here (using >&2) all output will be send to stderr on windows.
 			#       This is because redirection of streams is done by the client (windows) and windows does not support multiple redirections in one connection.
 			#       Hence, redirection cannot be used with windows:
@@ -305,7 +305,7 @@ class cmdRegEx():
         else:
             sshCmd = '{sshBinary} -A -T -o PasswordAuthentication=no -o ChallengeResponseAuthentication=no -o KbdInteractiveAuthentication=no -o PubkeyAuthentication=yes -o StrictHostKeyChecking=yes -l {username} {loginHost} '
             # set marker line - this allows to ignore any output before the actual command (read detailed comment above)
-            sshCmd = sshCmd + ' \'(echo -e \"\\n----- strudel stdout start -----\");\' ' + ' \'(perl -e \"print STDERR \\"\\n----- strudel stderr start -----\\"\");\' '
+            sshCmd = sshCmd + ' \'(echo -e \"\\n----- strudel stdout start -----\");\' ' + ' \'(perl -e \"print STDERR \\"\\n----- strudel stderr start -----\\n\\"\");\' '
         cmd=self.cmd
         if sys.platform.startswith("win"):
             escapedChars={'ampersand':'^&','pipe':'^|'}


### PR DESCRIPTION
… new line)